### PR TITLE
Update docker file to work with v1.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN pip3 install lxml
 RUN pip3 install setuptools
 
 RUN git clone https://github.com/tzutalin/labelImg
+WORKDIR /labelImg
+RUN pyrcc5 resources.qrc -o resources.py
 
 RUN pip3 install resources requests staty
 


### PR DESCRIPTION
See https://github.com/tzutalin/labelImg/issues/455

Working container: https://hub.docker.com/r/guysoft/labelimg